### PR TITLE
fix bug on wrong soft link path

### DIFF
--- a/git/setup_precommit_hook.sh
+++ b/git/setup_precommit_hook.sh
@@ -7,4 +7,4 @@ SRC=code-quality/git
 sudo pip install -r ${SRC}/requirements.txt
 
 # setup precommit hook by linking the pre-commit script to the git hooks directory
-cd ${GIT_ROOT}/.git/hooks/ && ln -s $(pwd)/${SRC}/pre-commit.py pre-commit
+cd ${GIT_ROOT} && ln -s $(pwd)/${SRC}/pre-commit.py .git/hooks/pre-commit


### PR DESCRIPTION
remove ".git/hook/" in the soft link